### PR TITLE
Add implicit ingress rule creation for venue-services proxy connection to the management console

### DIFF
--- a/terraform-unity/ecs.tf
+++ b/terraform-unity/ecs.tf
@@ -164,14 +164,10 @@ resource "aws_ecs_service" "httpd_service" {
 # Find the MC's ALB's security group (created before unity-proxy)
 data "aws_security_group" "mc_alb_sg" {
   tags = {
+    Name        = "Unity Management Console Load Balancer SG"
     Venue       = var.venue
     ServiceArea = "cs"
-    Component   = "Unity Management Console"
-    Name        = "Unity Management Console Load Balancer SG"
-    Project     = var.project
-    CreatedBy   = "cs"
-    Env         = var.venue
-    Stack       = "Unity Management Console"
+    Proj        = var.project
   }
 }
 

--- a/terraform-unity/lambda.tf
+++ b/terraform-unity/lambda.tf
@@ -22,6 +22,7 @@ resource "aws_lambda_function" "httpdlambda" {
     Service = "U-CS"
   }
 }
+
 resource "aws_security_group" "lambda_sg" {
   name        = "${var.project}-${var.venue}-httpd_lambda_sg"
   description = "Security group for httpd lambda service"

--- a/terraform-unity/networking.tf
+++ b/terraform-unity/networking.tf
@@ -48,12 +48,12 @@ resource "aws_lb_listener" "httpd_listener" {
   }
 }
 # Unity shared serive account ID
-data "aws_ssm_parameter" "shared_service_account_id"{
+data "aws_ssm_parameter" "shared_service_account_id" {
   name = var.ssm_account_id
 }
 
 #Unity shared serive account region
-data "aws_ssm_parameter" "shared_service_region"{
+data "aws_ssm_parameter" "shared_service_region" {
   name = var.ssm_region
 }
 
@@ -71,11 +71,11 @@ resource "aws_ssm_parameter" "mgmt_endpoint" {
 
 # New SSM parameter for management console
 resource "aws_ssm_parameter" "management_console_url" {
-  name  = "/unity/${var.project}/${var.venue}/component/management-console"
-  type  = "String"
+  name = "/unity/${var.project}/${var.venue}/component/management-console"
+  type = "String"
   value = jsonencode({
-    healthCheckUrl   = "https://www.${data.aws_ssm_parameter.shared-service-domain.value}:4443/${var.project}/${var.venue}/management/api/health_checks"
-    landingPageUrl   = "https://www.${data.aws_ssm_parameter.shared-service-domain.value}:4443/${var.project}/${var.venue}/management/ui/landing"
-    componentName    = "Management Console"
+    healthCheckUrl = "https://www.${data.aws_ssm_parameter.shared-service-domain.value}:4443/${var.project}/${var.venue}/management/api/health_checks"
+    landingPageUrl = "https://www.${data.aws_ssm_parameter.shared-service-domain.value}:4443/${var.project}/${var.venue}/management/ui/landing"
+    componentName  = "Management Console"
   })
 }

--- a/terraform-unity/variables.tf
+++ b/terraform-unity/variables.tf
@@ -40,10 +40,10 @@ variable "httpd_proxy_version" {
   default     = "0.16.0"
 }
 
-variable "ssm_account_id"{
+variable "ssm_account_id" {
   description = "Name of the SSM paramter for shared service account ID"
-  type = string
-  default = "/unity/shared-services/aws/account"
+  type        = string
+  default     = "/unity/shared-services/aws/account"
 }
 
 variable "ssm_region" {


### PR DESCRIPTION
## Purpose
- Adding an ingress rule from the venue-services proxy's security group to the previously created Management Console security group
    - This is to ensure connectivity after the Management Console's ALB security group is locked down
## Proposed Changes
- ADD `ecs_mc_alb_ingress_sg_rule` ingress rule to ensure connectivity to ALBSecurityGroup (and the Management Console) deployed by the unity-cs-infra cloudformation template
## Issues
- second part of unity-sds/unity-cs#431
## Testing
- Manually redeployed on a locked-down management console, and tested connection.