### PR TITLE
Changing base image to more updated image

### DIFF
--- a/.github/workflows/lambda-build.yml
+++ b/.github/workflows/lambda-build.yml
@@ -32,7 +32,7 @@ jobs:
           zip -r ../lambda.zip lambda.py
 
       - name: Upload packaged Lambda function
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: lambda-package
           path: lambda.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM ubuntu/apache2
-LABEL authors="barber"
+FROM httpd:2.4.62
 
-RUN apt update && apt install -y libapache2-mod-auth-openidc ca-certificates python3-boto3 && a2enmod auth_openidc proxy proxy_http proxy_html proxy_wstunnel ssl substitute rewrite headers && \
+RUN apt update && apt install -y apache2 libapache2-mod-auth-openidc ca-certificates python3-boto3 && a2enmod auth_openidc proxy proxy_http proxy_html proxy_wstunnel ssl substitute rewrite headers && \
     sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
 
 COPY write_site.py /usr/local/bin/


### PR DESCRIPTION
## Purpose

- Update our base image so as to pull in newer functionality (specifically the `addressttl` directive)

## Proposed Changes

- CHANGE dockerfile base image
- ADD explicit supporting package install (that is apparently not installed by default in base image

## Issues

- unity-sds/unity-cs#480

## Testing

- Tested in local docker build