### PR TITLE
Adding specific version pinning to terraform requirements

### DIFF
--- a/terraform-unity/versions.tf
+++ b/terraform-unity/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "~> 1.8.2"
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.2"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.50.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

- Add discrete version specifications into the terraform configuration to prevent inconsistency issues on other deployments

## Changes

- ADD versions.tf file with terraform, and aws versions

## Issues

- Tangential to unity-sds/unity-sps#59, which is currently roadblocked by deployment issues relating to the above
- REQUIRES unity-sds/unity-cs-infra#108 to be merged first