### PR TITLE
Updating config, base image, and default image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu/apache2
+FROM ubuntu/apache2:2.4-24.10_edge
 
 RUN apt update && apt install -y libapache2-mod-auth-openidc ca-certificates python3-boto3 && a2enmod auth_openidc proxy proxy_http proxy_html proxy_wstunnel ssl substitute rewrite headers && \
     sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf

--- a/terraform-unity/networking.tf
+++ b/terraform-unity/networking.tf
@@ -1,11 +1,11 @@
 # Create an Application Load Balancer (ALB)
 resource "aws_lb" "httpd_alb" {
-  name                       = "${var.project}-${var.venue}-httpd-alb"
+  name = "${var.project}-${var.venue}-httpd-alb"
   # temporary switch until SPS tests are fixed
   #internal                   = true
-  internal                   = false
-  load_balancer_type         = "application"
-  security_groups            = [aws_security_group.ecs_alb_sg.id]
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.ecs_alb_sg.id]
   # temporary switch until SPS tests are fixed
   #subnets                    = local.subnet_ids
   subnets                    = local.public_subnet_ids

--- a/terraform-unity/ssm.tf
+++ b/terraform-unity/ssm.tf
@@ -22,7 +22,7 @@ resource "aws_ssm_parameter" "managementproxy_config" {
   value      = <<-EOT
 
     <Location "/${var.project}/${var.venue}/management/">
-        ProxyPass "http://${var.mgmt_dns}/" upgrade=websocket retry=5 disablereuse=On
+        ProxyPass "http://${var.mgmt_dns}/" upgrade=websocket retry=5 addressttl=60
         ProxyPassReverse "http://${var.mgmt_dns}/"
         ProxyPreserveHost On
         FallbackResource /management/index.html

--- a/terraform-unity/variables.tf
+++ b/terraform-unity/variables.tf
@@ -37,7 +37,7 @@ variable "installprefix" {
 variable "httpd_proxy_version" {
   description = "The version of the httpd proxy container"
   type        = string
-  default     = "0.16.0"
+  default     = "0.16.3"
 }
 
 variable "ssm_account_id" {


### PR DESCRIPTION
## Purpose

Update the base image of the unity-proxy service in order to support usage of the `addressttl` directive.

## Proposed Changes

- CHANGE docker image base image to new tag
- CHANGE terraform image tag references

## Issues

- unity-sds/unity-cs#480

## Testing

- Tested in personal management console deploy.